### PR TITLE
Unclaim changes

### DIFF
--- a/activeclaim/urls.py
+++ b/activeclaim/urls.py
@@ -5,5 +5,6 @@ urlpatterns = [
     path('', views.get_routes),
     path('create/<str:pk>/', views.create_active_claim),
     path('complete/<str:pk>/', views.complete_active_claim),
+    path('unclaim/<str:pk>/', views.unclaim_active_claim),
     path('list/', views.list_active_claims),
 ]


### PR DESCRIPTION
Testing Unclaim Active Cases

Unclaiming cases via a new endpoint: DELETE /api/activeclaim/unclaim/<casenum>/.

Permissions:
- Users in the Tech group can only unclaim cases assigned to themselves.
- Users in the Lead group can unclaim any case.

Setup:

1. Ensure the backend server is running.
2. Using the Django Admin:
    - Obtain tokens for both a tech, tech2 and the lead user
    -Create an active case under tech2

Testing Steps:

1. Attempt Unclaim Non-Existent:
   Command: curl -X DELETE -H "Authorization: Token <TECH_TOKEN>" http://localhost:8000/api/activeclaim/unclaim/99999999/
   Expect: {"error":"Claim not found"}

2. Tech1 Tries Unclaiming Other's:
   Command: curl -X DELETE -H "Authorization: Token <TECH_TOKEN>" http://localhost:8000/api/activeclaim/unclaim/tech2_casenumber/
   Expect: {"error":"Permission denied. You can only unclaim your own cases."}

3. Lead Unclaims Other's:
   Command: curl -X DELETE -H "Authorization: Token <LEAD_TOKEN>" http://localhost:8000/api/activeclaim/unclaim/tech2_casenumber/
   Expect: *Case is removed on "Active claims"*

4. Tech2 Unclaims Own:
   Command: curl -X DELETE -H "Authorization: Token <TECH_TOKEN>" http://localhost:8000/api/activeclaim/unclaim/tech2_casenumber/
   Expect: *Case is removed on "Active claims"*